### PR TITLE
Correct type for localVarPostBody

### DIFF
--- a/api_artifacts.go
+++ b/api_artifacts.go
@@ -239,7 +239,7 @@ func (a *ArtifactsApiService) CreateArtifactExecute(r ApiCreateArtifactRequest) 
 		localVarHeaderParams["X-Registry-Name-Encoded"] = parameterToString(*r.xRegistryNameEncoded, "")
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = *r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err


### PR DESCRIPTION
I saw this regression when `setBody()` from `client.go` was not able to cast my string because `body` was of type `*interface{}` instead of `interface{}`.
I think it's fine to correct it like that because `localVarPostBody` is declared as an `interface{}`.